### PR TITLE
docs and private ctors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 files
 =====
 
-This package defines filesystem APIs that can be implemented for difference
+This package defines filesystem APIs that can be implemented for different
 environments such as dart:io, Chrome Apps, or network filesystems.
 
 The API includes `FileSystem`, `File` and `Directory` classes with interfaces
 similar to those in dart:io, excluding synchronous operations and constructors.
 
-All `File` and `Directory` should not have public constructors, and instances
-should only be retreived via a `FileSystem` instance. This ensures that code
-that uses the interfaces defined here can work with any implementations.
+All `File` and `Directory` implementations should not have public constructors,
+and instances should only be retreived via a `FileSystem` instance. This ensures
+that code that uses the interfaces defined here can work with any
+implementations.
 
 ## Status
 

--- a/lib/files.dart
+++ b/lib/files.dart
@@ -2,6 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/**
+ * This package defines filesystem APIs that can be implemented for different
+ * environments such as dart:io, Chrome Apps, or network filesystems.
+ *
+ * The API includes `FileSystem`, `File` and `Directory` classes with interfaces
+ * similar to those in dart:io, excluding synchronous operations and
+ * constructors.
+ */
 library files;
 
 import 'dart:async';

--- a/lib/html.dart
+++ b/lib/html.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/**
+ * A [FileSystem] implementation for the `dart:html` (Html5) file system.
+ */
 library files.html;
 
 import 'dart:async';
@@ -9,7 +12,6 @@ import 'dart:convert';
 import 'dart:html' as html;
 import 'dart:typed_data';
 
-import 'package:path/path.dart' as pathlib;
 import 'package:quiver/async.dart';
 
 import 'files.dart';
@@ -29,13 +31,13 @@ abstract class HtmlFileSystemEntry implements FileSystemEntry {
   final HtmlFileSystem _fs;
   final String _path;
 
-  HtmlFileSystemEntry(this._fs, this._path);
+  HtmlFileSystemEntry._(this._fs, this._path);
 
   String get path => _path;
 }
 
 class HtmlFile extends HtmlFileSystemEntry implements File {
-  HtmlFile._(HtmlFileSystem fs, String path) : super(fs, path);
+  HtmlFile._(HtmlFileSystem fs, String path) : super._(fs, path);
 
   String get path => _path;
 
@@ -182,7 +184,7 @@ class _FileStreamConsumer extends StreamConsumer<List<int>> {
 }
 
 class HtmlDirectory extends HtmlFileSystemEntry implements Directory {
-  HtmlDirectory._(HtmlFileSystem fs, String path) : super(fs, path);
+  HtmlDirectory._(HtmlFileSystem fs, String path) : super._(fs, path);
 
   @override
   Future<Directory> create({bool recursive: false}) {

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -2,36 +2,39 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/**
+ * A [FileSystem] implementation for the `dart:io` library.
+ */
 library files.io;
 
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
 
+import 'package:quiver/async.dart';
 import 'package:quiver/io.dart';
 
 import 'files.dart';
-import 'package:quiver/async.dart';
 export 'files.dart';
 
 class IoFileSystem implements FileSystem {
 
-  IoFile getFile(String path) => new IoFile(new io.File(path));
+  IoFile getFile(String path) => new IoFile._(new io.File(path));
 
   IoDirectory getDirectory(String path) =>
-      new IoDirectory(new io.Directory(path));
+      new IoDirectory._(new io.Directory(path));
 }
 
 abstract class IoFileSystemEntry implements FileSystemEntry {
   final io.FileSystemEntity _entity;
 
-  IoFileSystemEntry(this._entity);
+  IoFileSystemEntry._(this._entity);
 
   String get path => _entity.path;
 }
 
 class IoFile extends IoFileSystemEntry implements File {
-  IoFile(io.File file) : super(file);
+  IoFile._(io.File file) : super._(file);
 
   io.File get _file => _entity;
 
@@ -52,14 +55,14 @@ class IoFile extends IoFileSystemEntry implements File {
       _file.writeAsString(contents, encoding: encoding).then((f) => this);
 
   Future<IoFile> rename(String newPath) =>
-      _file.rename(newPath).then((f) => new IoFile(f));
+      _file.rename(newPath).then((f) => new IoFile._(f));
 
   Future<IoFile> delete({bool recursive: false}) =>
-      _file.delete(recursive: recursive).then((f) => new IoFile(f));
+      _file.delete(recursive: recursive).then((f) => new IoFile._(f));
 }
 
 class IoDirectory extends IoFileSystemEntry implements Directory {
-  IoDirectory(io.Directory directory) : super(directory);
+  IoDirectory._(io.Directory directory) : super._(directory);
 
   io.Directory get _directory => _entity;
 
@@ -67,10 +70,10 @@ class IoDirectory extends IoFileSystemEntry implements Directory {
       _directory.create(recursive: recursive).then((_) => this);
 
   Future<IoDirectory> rename(String newPath) =>
-      _directory.rename(newPath).then((d) => new IoDirectory(d));
+      _directory.rename(newPath).then((d) => new IoDirectory._(d));
 
   Future<IoDirectory> delete({bool recursive}) =>
-      _directory.delete(recursive: recursive).then((d) => new IoDirectory(d));
+      _directory.delete(recursive: recursive).then((d) => new IoDirectory._(d));
 
   Stream<FileSystemEntry> list({bool recursive: false,
       bool followLinks: true}) =>
@@ -79,8 +82,8 @@ class IoDirectory extends IoFileSystemEntry implements Directory {
 }
 
 FileSystemEntry _wrap(io.FileSystemEntity e) {
-  if (e is io.File) return new IoFile(e);
-  if (e is io.Directory) return new IoDirectory(e);
+  if (e is io.File) return new IoFile._(e);
+  if (e is io.Directory) return new IoDirectory._(e);
   if (e is io.Link) throw new UnsupportedError('Links not supported');
   throw new ArgumentError(e);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,4 +6,5 @@ description: A filesystem API with implementations for multiple environments
 dependencies:
   quiver: '>=0.19.0-dev.3 <1.0.0'
 dev_dependencies:
+  browser: any
   unittest: '>=0.9.2 <=0.12.0'

--- a/test/html_test.html
+++ b/test/html_test.html
@@ -1,15 +1,15 @@
+<!DOCTYPE html>
+
 <!-- Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
      for details. All rights reserved. Use of this source code is governed by a
      BSD-style license that can be found in the LICENSE file. -->
-
-<!DOCTYPE html>
 
 <html>
   <head>
   	<meta charset="utf-8">
     <title>html_file_test</title>
   </head>
- 
+
   <body>
     <script type="application/dart" src="html_test.dart"></script>
     <script src="packages/browser/dart.js"></script>


### PR DESCRIPTION
- add some docs
- make some public ctors private, to reconcile with what the docs were saying
- add a `browser` dependency, which the test directory needs
- move the `doctype` to the top of the html file, to make some browsers happy

@justinfagnani
