### PR TITLE
fix some analysis warnings (that are failing the build)

### DIFF
--- a/lib/files.dart
+++ b/lib/files.dart
@@ -63,10 +63,6 @@ abstract class Directory extends FileSystemEntry {
 
   Future<Directory> create({bool recursive: false});
 
-  Future<Directory> delete({bool recursive});
-
-  Future<Directory> rename(String newPath);
-
   Stream<FileSystemEntry> list({bool recursive: false, bool followLinks: true});
 }
 
@@ -83,6 +79,7 @@ class FileMode {
   /// The mode for opening a file for reading and writing to the
   /// end of it. The file is created if it does not already exist.
   static const APPEND = const FileMode._internal(2);
+
   final int _mode;
 
   const FileMode._internal(this._mode);

--- a/lib/html.dart
+++ b/lib/html.dart
@@ -199,7 +199,7 @@ class HtmlDirectory extends HtmlFileSystemEntry implements Directory {
   }
 
   @override
-  Future<Directory> delete({bool recursive}) {
+  Future<Directory> delete({bool recursive: false}) {
     // TODO: implement delete
     return new Future.error(new UnimplementedError());
   }

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -69,7 +69,7 @@ class IoDirectory extends IoFileSystemEntry implements Directory {
   Future<IoDirectory> rename(String newPath) =>
       _directory.rename(newPath).then((d) => new IoDirectory._(d));
 
-  Future<IoDirectory> delete({bool recursive}) =>
+  Future<IoDirectory> delete({bool recursive: false}) =>
       _directory.delete(recursive: recursive).then((d) => new IoDirectory._(d));
 
   Stream<FileSystemEntry> list({bool recursive: false,


### PR DESCRIPTION
Fix some override warnings (that were failing the drone build).

```
[warning] Parameters cannot override default values, this method overrides 'FileSystemEntry.delete' where 'recursive' has a different value (/files.dart/lib/html.dart, line 202, col 29)
```